### PR TITLE
fix : 메서드명, 입력 반환 변수 명 변경

### DIFF
--- a/src/main/java/com/example/shimpyo/domain/auth/dto/UserLoginDto.java
+++ b/src/main/java/com/example/shimpyo/domain/auth/dto/UserLoginDto.java
@@ -10,6 +10,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class UserLoginDto {
-    private String loginId;
+    private String username;
     private String password;
+    // 자동 로그인
+    private Boolean isRememberMe;
 }

--- a/src/main/java/com/example/shimpyo/domain/user/controller/AuthController.java
+++ b/src/main/java/com/example/shimpyo/domain/user/controller/AuthController.java
@@ -31,12 +31,10 @@ public class AuthController {
     // [#MOO3] 유저 로그인 시작
     @PostMapping("/login")
     public ResponseEntity<?> login(@RequestBody UserLoginDto dto) throws JsonProcessingException {
-        UserAuth userAuth = authService.login(dto);
+        LoginResponseDto loginResponseDto = authService.login(dto);
 
-        String jwtToken = jwtTokenProvider.createToken(userAuth.getUserLoginId());
-        Map<String,Object> loginInfo = new HashMap<>();
-        loginInfo.put("userToken", jwtToken);
-        return ResponseEntity.ok(jwtToken);
+        String jwtToken = jwtTokenProvider.createToken(loginResponseDto.getUserId().toString());
+        return ResponseEntity.ok(loginResponseDto);
     }
     // [#MOO3] 유저 로그인 끝
 }

--- a/src/main/java/com/example/shimpyo/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/shimpyo/domain/user/controller/UserController.java
@@ -20,24 +20,15 @@ public class UserController {
     // [#MOO1] 사용자 회원가입 시작
     @PostMapping("/signup")
     public ResponseEntity<?> registerUser(@RequestBody RegisterUserRequest dto){
-        try {
-            authService.registerUser(dto);
-            return ResponseEntity.ok("회원가입 완료");
-        }catch (BaseException e){
-            return ResponseEntity.badRequest().body(e.getMessage());
-        }
-
+        authService.registerUser(dto);
+        return ResponseEntity.ok("회원가입 완료");
     }
     // [#MOO1] 사용자 회원가입 끝
 
     // [#M002] 이메일 검증 시작
     @GetMapping("/check/email/duplicate")
     public ResponseEntity<?> getEmail(@RequestParam String email){
-        try{
-            return ResponseEntity.ok(authService.emailCheck(email));
-        }catch (BaseException e){
-            return new ResponseEntity<>(e.getMessage(), HttpStatus.CONFLICT);
-        }
+        return ResponseEntity.ok(authService.emailCheck(email));
     }
     // [#M002] 이메일 검증 끝
 }

--- a/src/main/java/com/example/shimpyo/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/shimpyo/domain/user/controller/UserController.java
@@ -5,13 +5,9 @@ import com.example.shimpyo.domain.user.dto.RegisterUserRequest;
 import com.example.shimpyo.global.BaseException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.HashMap;
-import java.util.Map;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -23,19 +19,19 @@ public class UserController {
 
     // [#MOO1] 사용자 회원가입 시작
     @PostMapping("/signup")
-    public ResponseEntity<?> registerMember(@RequestBody RegisterUserRequest dto){
+    public ResponseEntity<?> registerUser(@RequestBody RegisterUserRequest dto){
         try {
-            authService.registerMember(dto);
-            return new ResponseEntity<>("signup success!!", HttpStatus.OK);
+            authService.registerUser(dto);
+            return ResponseEntity.ok("회원가입 완료");
         }catch (BaseException e){
-            return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
+            return ResponseEntity.badRequest().body(e.getMessage());
         }
 
     }
     // [#MOO1] 사용자 회원가입 끝
 
     // [#M002] 이메일 검증 시작
-    @GetMapping("/check/email")
+    @GetMapping("/check/email/duplicate")
     public ResponseEntity<?> getEmail(@RequestParam String email){
         try{
             return ResponseEntity.ok(authService.emailCheck(email));

--- a/src/main/java/com/example/shimpyo/domain/user/dto/RegisterUserRequest.java
+++ b/src/main/java/com/example/shimpyo/domain/user/dto/RegisterUserRequest.java
@@ -6,33 +6,30 @@ import com.example.shimpyo.domain.user.entity.UserAuth;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 public class RegisterUserRequest {
     private String email;
-    private String nickname;
-    private String userLoginId;
+    private String username;
     private String password;
 
 
     // [#MOO1] 사용자 등록
     public UserAuth toUserAuthEntity(String password, User user) {
         return UserAuth.builder()
-                .userLoginId(this.userLoginId)
+                .userLoginId(this.username)
                 .user(user)
                 .password(password)
                 .socialType(SocialType.LOCAL)
                 .build();
     }
     // [#MOO1] 사용자 등록
-    public User toUserEntity(){
+    public User toUserEntity(String nickname){
         return User.builder()
                 .email(this.email)
-                .nickname(this.nickname)
+                .nickname(nickname)
                 .build();
     }
 }

--- a/src/main/java/com/example/shimpyo/domain/user/service/AuthService.java
+++ b/src/main/java/com/example/shimpyo/domain/user/service/AuthService.java
@@ -5,6 +5,7 @@ import com.example.shimpyo.domain.user.dto.LoginResponseDto;
 import com.example.shimpyo.domain.user.dto.RegisterUserRequest;
 import com.example.shimpyo.domain.user.entity.User;
 import com.example.shimpyo.domain.user.entity.UserAuth;
+import com.example.shimpyo.domain.user.oauth.NicknamePrefixLoader;
 import com.example.shimpyo.domain.user.repository.UserAuthRepository;
 import com.example.shimpyo.domain.user.repository.UserRepository;
 import com.example.shimpyo.global.BaseException;
@@ -34,7 +35,7 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
 
     // [#MOO1] 사용자 회원가입 시작
-    public void registerMember(RegisterUserRequest dto) {
+    public void registerUser(RegisterUserRequest dto) {
         // [#MOO1] 이메일 중복 여부 확인 (deleted_at = null 인 사용자만 대상으로)
         if (userRepository.findByEmailAndDeletedAtIsNull(dto.getEmail()).isPresent()) {
             throw new BaseException(EMAIL_DUPLICATION);
@@ -42,7 +43,7 @@ public class AuthService {
         // 삭제한 사용자는 우쨤?
 
         // [#MOO1] 회원 등록 (비밀번호는 인코딩해서 저장)
-        User user = userRepository.save(dto.toUserEntity());
+        User user = userRepository.save(dto.toUserEntity(NicknamePrefixLoader.generateNickNames()));
         userAuthRepository.save(dto.toUserAuthEntity(passwordEncoder.encode(dto.getPassword()), user));
     }
     // [#MOO1] 사용자 회원가입 끝
@@ -58,11 +59,11 @@ public class AuthService {
     // [#MOO2] 이메일 인증 끝
 
     // [#MOO3] 유저 로그인 시작
-    public UserAuth login(UserLoginDto dto){
-        UserAuth userAuth = userAuthRepository.findByUserLoginId(dto.getLoginId())
+    public LoginResponseDto login(UserLoginDto dto){
+        UserAuth userAuth = userAuthRepository.findByUserLoginId(dto.getUsername())
                 .orElseThrow(() -> new BaseException(MEMBER_NOT_FOUND));
 
-        return userAuth;
+        return LoginResponseDto.toDto(userAuth);
     }
     // [#MOO3] 유저 로그인 끝
 }


### PR DESCRIPTION
1. [#MOO1] 메서드 명 변경 registerMember -> registerUser 
1.1 반환 정보 변경
1.2 RequestBody의 RegisterUserRequest의 변수 명 변경
3. [#MOO2] 이메일 검증 URL 변경
4. [#MOO3] 로그인 로직 수정 
3.1 RequestBody의 UserLoginDto의 변수 수정
3.2 반환 시 loginResponseDto 형식으로 반환

### ⚡이슈 번호
resolve #

---
### ✅ PR 종류
- [ ] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
-
---
### 📖 참고 사항
