### PR TITLE
fix : 이메일 인증 변경

### DIFF
--- a/src/main/java/com/example/shimpyo/domain/auth/service/MailService.java
+++ b/src/main/java/com/example/shimpyo/domain/auth/service/MailService.java
@@ -1,11 +1,14 @@
 package com.example.shimpyo.domain.auth.service;
 
 import com.example.shimpyo.domain.auth.dto.MailVerifyDto;
+import com.example.shimpyo.domain.user.dto.MailCodeSendDto;
+import com.example.shimpyo.domain.user.repository.UserRepository;
 import com.example.shimpyo.global.BaseException;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
@@ -15,6 +18,8 @@ import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 import static com.example.shimpyo.global.exceptionType.AuthException.MAIL_CODE_NOT_MATCHED;
+import static com.example.shimpyo.global.exceptionType.MemberExceptionType.EMAIL_DUPLICATION;
+import static com.example.shimpyo.global.exceptionType.MemberExceptionType.EMAIL_NOT_FOUNDED;
 
 @Transactional
 @RequiredArgsConstructor
@@ -22,10 +27,29 @@ import static com.example.shimpyo.global.exceptionType.AuthException.MAIL_CODE_N
 public class MailService {
 
     private final JavaMailSender mailSender;
+    @Qualifier("1")
     private final RedisTemplate<String, Object> redisTemplate;
+    private final UserRepository userRepository;
     
     // [#MOO4] 메일 전송 시작 
-    public void authEmail(String email) {
+    public void authEmail(MailCodeSendDto dto) {
+        String email = "";
+        
+        /*
+        * 메일 전송 타입 : register 인 경우 메일이 존재할 경우 : "이미 가입된 이메일 입니다." 예외 처리
+        * 메일 전송 타입 : find 인 경우 메일이 존재하지 않을 경우 : "해당 이메일이 존재하지 않습니다." 예외 처리
+         */
+        if(dto.getType().equals("register")){
+            if (userRepository.findByEmail(dto.getEmail()).isPresent()) {
+                throw new BaseException(EMAIL_DUPLICATION);
+            }else{
+                email = dto.getEmail();
+            }
+        }else if(dto.getType().equals("find")){
+            email = userRepository.findByEmail(dto.getEmail())
+                    .orElseThrow(() -> new BaseException(EMAIL_NOT_FOUNDED)).getEmail();
+        }
+
         Random random = new Random();
 
         StringBuilder authkey = new StringBuilder();

--- a/src/main/java/com/example/shimpyo/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/shimpyo/domain/user/controller/UserController.java
@@ -2,6 +2,7 @@ package com.example.shimpyo.domain.user.controller;
 
 import com.example.shimpyo.domain.auth.dto.MailVerifyDto;
 import com.example.shimpyo.domain.auth.service.MailService;
+import com.example.shimpyo.domain.user.dto.MailCodeSendDto;
 import com.example.shimpyo.domain.user.service.AuthService;
 import com.example.shimpyo.domain.user.dto.RegisterUserRequest;
 import com.example.shimpyo.domain.user.service.UserService;
@@ -43,8 +44,8 @@ public class UserController {
 
     // [#MOO4] 이메일 인증 코드 발급 시작
     @PostMapping("/email")
-    public ResponseEntity<?> sendEmail(@RequestParam String email){
-        mailService.authEmail(email);
+    public ResponseEntity<?> sendEmail(@RequestBody MailCodeSendDto dto){
+        mailService.authEmail(dto);
 
         return ResponseEntity.ok("이메일을 전송하였습니다.");
     }

--- a/src/main/java/com/example/shimpyo/domain/user/dto/MailCodeSendDto.java
+++ b/src/main/java/com/example/shimpyo/domain/user/dto/MailCodeSendDto.java
@@ -1,0 +1,14 @@
+package com.example.shimpyo.domain.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class MailCodeSendDto {
+
+    private String email;
+    private String type;
+}

--- a/src/main/java/com/example/shimpyo/global/exceptionType/MemberExceptionType.java
+++ b/src/main/java/com/example/shimpyo/global/exceptionType/MemberExceptionType.java
@@ -13,6 +13,7 @@ public enum MemberExceptionType implements ExceptionType{
     INVALID_VERIFICATION(BAD_REQUEST, "잘못된 이메일 인증 요청입니다."),
     INVALID_PROFILE_IMAGE(BAD_REQUEST, "잘못된 형식의 프로필 사진입니다."),
     EMAIL_DUPLICATION(BAD_REQUEST, "이미 가입된 이메일 입니다."),
+    EMAIL_NOT_FOUNDED(BAD_REQUEST, "해당 이메일이 존재하지 않습니다."),
     NICKNAME_NOT_VALID(BAD_REQUEST, "닉네임 형식이 올바르지 않습니다.");
 
     private final HttpStatus status;

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -27,7 +27,7 @@ spring:
     host: smtp.gmail.com
     port: 587
     username: anflwkd@gmail.com
-    password:
+    password: blyt ibid lbby mzes
     properties:
       mail:
         smtp:


### PR DESCRIPTION
### ⚡이슈 번호
resolve #21 

---
### ✅ PR 종류
- [ ] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
1. @RequestParam -> @RequestBody 변경
2. MailCodeSendDto 를 통해 body 를 받음
3. dto 의 type을 기준으로 분기 설정
---
### 📖 참고 사항
- aaa@aaa.com 이라는 이메일이 존재함
![image](https://github.com/user-attachments/assets/58b05fa7-4648-4485-9ccc-e9aed3d4ed86)
![image](https://github.com/user-attachments/assets/63ded72a-e555-43bb-8021-677f2b85e85a)

- AAAA@AAAA.com 이라는 이메일이 존재하지 않음
![image](https://github.com/user-attachments/assets/2e76cdaf-777b-41a3-a018-f234d1bebce2)
![image](https://github.com/user-attachments/assets/0e93b041-8784-412c-8505-db9bdca6a20d)

