### PR TITLE
Fix/is 32

### DIFF
--- a/src/main/java/com/example/shimpyo/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/shimpyo/domain/auth/controller/AuthController.java
@@ -6,10 +6,13 @@ import com.example.shimpyo.domain.auth.service.OAuth2Service;
 import com.example.shimpyo.domain.auth.service.AuthService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.mail.MessagingException;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
@@ -86,5 +89,28 @@ public class AuthController {
         FindUsernameResponseDto responseDto = authService.findUsername(requestDto);
 
         return ResponseEntity.ok(responseDto);
+    }
+
+    @Operation(summary = "비밀번호 찾기")
+    @PatchMapping("/password")
+    public ResponseEntity<Void> sendPasswordMail(@Valid @RequestBody FindPasswordRequestDto requestDto) throws MessagingException {
+        authService.sendPasswordResetMail(requestDto);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "비밀번호 변경")
+    @PutMapping("/password")
+    public ResponseEntity<Void> resetPassword(@AuthenticationPrincipal UserDetails user,
+                                              @Valid @RequestBody ResetPasswordRequestDto requestDto) {
+        authService.resetPassword(user.getUsername(), requestDto);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "회원 탈퇴")
+    @DeleteMapping
+    public ResponseEntity<Void> deleteUser(@RequestParam String username) {//@AuthenticationPrincipal UserDetails user) {
+        authService.deleteUser(username);
+//        authService.deleteUser(user.getUsername());
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/example/shimpyo/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/shimpyo/domain/auth/controller/AuthController.java
@@ -7,6 +7,7 @@ import com.example.shimpyo.domain.auth.service.AuthService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -38,7 +39,7 @@ public class AuthController {
 
     // [#MOO1] 사용자 회원가입 시작
     @PostMapping("/signup")
-    public ResponseEntity<?> registerUser(@RequestBody RegisterUserRequest dto){
+    public ResponseEntity<?> registerUser(@Valid @RequestBody RegisterUserRequest dto){
         authService.registerUser(dto);
         return ResponseEntity.ok("회원가입 완료");
     }

--- a/src/main/java/com/example/shimpyo/domain/auth/dto/FindPasswordRequestDto.java
+++ b/src/main/java/com/example/shimpyo/domain/auth/dto/FindPasswordRequestDto.java
@@ -1,0 +1,14 @@
+package com.example.shimpyo.domain.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FindPasswordRequestDto {
+
+    private String username;
+    @Email
+    private String email;
+}

--- a/src/main/java/com/example/shimpyo/domain/auth/dto/RegisterUserRequest.java
+++ b/src/main/java/com/example/shimpyo/domain/auth/dto/RegisterUserRequest.java
@@ -3,6 +3,7 @@ package com.example.shimpyo.domain.auth.dto;
 import com.example.shimpyo.domain.user.entity.SocialType;
 import com.example.shimpyo.domain.user.entity.User;
 import com.example.shimpyo.domain.auth.entity.UserAuth;
+import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -12,7 +13,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class RegisterUserRequest {
     private String email;
+
+    @Pattern(regexp = "^[a-z0-9]{6,12}$", message = "아이디가 유효하지 않습니다.[영 소문자 + 숫자 (6~12자)]")
     private String username;
+
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[~!@#$%^&*])[A-Za-z\\d~!@#$%^&*]{8,}$\n",
+    message = "비밀번호 형식이 일치하지 않습니다.")
     private String password;
 
 

--- a/src/main/java/com/example/shimpyo/domain/auth/dto/RegisterUserRequest.java
+++ b/src/main/java/com/example/shimpyo/domain/auth/dto/RegisterUserRequest.java
@@ -17,7 +17,7 @@ public class RegisterUserRequest {
     @Pattern(regexp = "^[a-z0-9]{6,12}$", message = "아이디가 유효하지 않습니다.[영 소문자 + 숫자 (6~12자)]")
     private String username;
 
-    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[~!@#$%^&*])[A-Za-z\\d~!@#$%^&*]{8,}$\n",
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[~!@#$%^&*])[A-Za-z\\d~!@#$%^&*]{8,}$",
     message = "비밀번호 형식이 일치하지 않습니다.")
     private String password;
 

--- a/src/main/java/com/example/shimpyo/domain/auth/dto/ResetPasswordRequestDto.java
+++ b/src/main/java/com/example/shimpyo/domain/auth/dto/ResetPasswordRequestDto.java
@@ -1,0 +1,18 @@
+package com.example.shimpyo.domain.auth.dto;
+
+import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ResetPasswordRequestDto {
+
+    private String nowPassword;
+
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[~!@#$%^&*])[A-Za-z\\d~!@#$%^&*]{8,}$",
+            message = "비밀번호 형식이 일치하지 않습니다.")
+    private String newPassword;
+
+    private String checkNewPassword;
+}

--- a/src/main/java/com/example/shimpyo/domain/auth/entity/UserAuth.java
+++ b/src/main/java/com/example/shimpyo/domain/auth/entity/UserAuth.java
@@ -40,4 +40,8 @@ public class UserAuth extends BaseEntity {
     @MapsId
     @JoinColumn(name = "user_id")
     private User user;
+
+    public void resetPassword(String newPassword) {
+        this.password = newPassword;
+    }
 }

--- a/src/main/java/com/example/shimpyo/domain/auth/repository/UserAuthRepository.java
+++ b/src/main/java/com/example/shimpyo/domain/auth/repository/UserAuthRepository.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 
 public interface UserAuthRepository extends JpaRepository<UserAuth, Long> {
 
-    Optional<UserAuth> findByUserLoginIdAndSocialType(String userLoginId, SocialType socialType);
+    Optional<UserAuth> findByUserLoginIdAndSocialTypeAndDeletedAtIsNull(String userLoginId, SocialType socialType);
 
     Optional<UserAuth> findByUserLoginId(String userLoginId);
 

--- a/src/main/java/com/example/shimpyo/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/shimpyo/domain/auth/service/AuthService.java
@@ -49,7 +49,6 @@ public class AuthService {
 
     // [#MOO1] 사용자 회원가입 시작
     public void registerUser(RegisterUserRequest dto) {
-        validateUsername(dto.getUsername());
         // [#MOO1] 이메일 중복 여부 확인 (deleted_at = null 인 사용자만 대상으로)
         if (userRepository.findByEmailAndDeletedAtIsNull(dto.getEmail()).isPresent()) {
             throw new BaseException(EMAIL_DUPLICATION);
@@ -61,16 +60,6 @@ public class AuthService {
         userAuthRepository.save(dto.toUserAuthEntity(passwordEncoder.encode(dto.getPassword()), user));
     }
     // [#MOO1] 사용자 회원가입 끝
-
-    // 회원가입 시 자체적인 아이디 유효성 검사
-    private void validateUsername(String username) {
-        if( username.length() > 12 || username.length() < 6){
-            throw new BaseException(USERNAME_NOT_VALIDATE);
-        }
-        if( !username.matches("^[a-z0-9]^")){
-            throw new BaseException(USERNAME_NOT_VALIDATE);
-        }
-    }
 
     // [#MOO2] 이메일 인증 시작
     public Map<String, Boolean> emailCheck(String email) {

--- a/src/main/java/com/example/shimpyo/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/shimpyo/domain/auth/service/AuthService.java
@@ -241,8 +241,10 @@ public class AuthService {
                 .orElseThrow(() -> new BaseException(MEMBER_NOT_FOUND));
         if (userAuth.getDeletedAt() != null)
             throw new BaseException(MEMBER_NOT_FOUND);
-//        if (userAuth.getSocialType().equals(SocialType.KAKAO))
-//            oAuth2Service.unlinkKaKao(userAuth);
+
+        if (userAuth.getSocialType().equals(SocialType.KAKAO))
+            oAuth2Service.unlinkKaKao(userAuth);
+
         userAuth.delete();
     }
 

--- a/src/main/java/com/example/shimpyo/domain/auth/service/MailService.java
+++ b/src/main/java/com/example/shimpyo/domain/auth/service/MailService.java
@@ -2,6 +2,7 @@ package com.example.shimpyo.domain.auth.service;
 
 import com.example.shimpyo.domain.auth.dto.MailVerifyDto;
 import com.example.shimpyo.domain.auth.dto.MailCodeSendDto;
+import com.example.shimpyo.domain.auth.entity.UserAuth;
 import com.example.shimpyo.domain.user.repository.UserRepository;
 import com.example.shimpyo.global.BaseException;
 import jakarta.mail.MessagingException;
@@ -34,12 +35,6 @@ public class MailService {
     @Qualifier("1")
     private final RedisTemplate<String, Object> redisTemplate;
     private final UserRepository userRepository;
-
-    private static final String LETTERS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
-    private static final String NUMBERS = "0123456789";
-    private static final String SPECIALS = "~!@#$%^&*";
-    private static final String ALL = LETTERS + NUMBERS + SPECIALS;
-    private static final SecureRandom random = new SecureRandom();
     
     // [#MOO4] 메일 전송 시작 
     public void authEmail(MailCodeSendDto dto) {
@@ -103,9 +98,10 @@ public class MailService {
     // [#MOO5] 메일 정보와 인증 코드 일치 여부 판단 로직 끝
 
     // 회원 이메일로 임시 비밀번호 전송
-    public void sendResetPasswordMail(String email) throws MessagingException {
+    public void sendResetPasswordMail(String email, String tempPW) throws MessagingException {
+
         String subject = "ShimPyoSo Authorization";
-        String text = "임시 비밀번호는 " + generatePassword() + "입니다.";
+        String text = "임시 비밀번호는 " + tempPW + "입니다.";
 
         MimeMessage mimeMessage = mailSender.createMimeMessage();
         MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, true, "utf-8");
@@ -116,21 +112,5 @@ public class MailService {
         mailSender.send(mimeMessage);
     }
 
-    private static String generatePassword() {
-        List<Character> passwordChars = new ArrayList<>();
 
-        passwordChars.add(LETTERS.charAt(random.nextInt(LETTERS.length())));
-        passwordChars.add(NUMBERS.charAt(random.nextInt(NUMBERS.length())));
-        passwordChars.add(SPECIALS.charAt(random.nextInt(SPECIALS.length())));
-
-        for (int i = 3; i < 8; i++) {
-            passwordChars.add(ALL.charAt(random.nextInt(ALL.length())));
-        }
-        Collections.shuffle(passwordChars);
-        StringBuilder password = new StringBuilder();
-        for (char ch : passwordChars) {
-            password.append(ch);
-        }
-        return password.toString();
-    }
 }

--- a/src/main/java/com/example/shimpyo/domain/auth/service/OAuth2Service.java
+++ b/src/main/java/com/example/shimpyo/domain/auth/service/OAuth2Service.java
@@ -29,7 +29,7 @@ public class OAuth2Service {
 
     private final UserRepository userRepository;
     private final UserAuthRepository userAuthRepository;
-    private final OAuth2AuthorizedClientService oauthService;
+//    private final OAuth2AuthorizedClientService oauthService;
 
     @Transactional
     public LoginResponseDto kakaoLogin(String accessToken) throws JsonProcessingException {
@@ -75,7 +75,7 @@ public class OAuth2Service {
         return LoginResponseDto.toDto(user);
     }
 
-    public void unlinkKaKao(UserAuth userAuth) {
+    /*public void unlinkKaKao(UserAuth userAuth) {
         OAuth2AuthorizedClient authorizedClient = oauthService.loadAuthorizedClient(
                 "kakao", // OAuth2 로그인 제공자 이름
                 userAuth.getUserLoginId() // 카카오 사용자의 이메일
@@ -101,5 +101,5 @@ public class OAuth2Service {
                 entity,                          // HttpEntity (본문 없음, 헤더만 있음)
                 String.class                     // 응답 타입
         );
-    }
+    }*/
 }

--- a/src/main/java/com/example/shimpyo/domain/common/BaseEntity.java
+++ b/src/main/java/com/example/shimpyo/domain/common/BaseEntity.java
@@ -25,4 +25,8 @@ public abstract class BaseEntity {
     private LocalDateTime updatedAt;
 
     private LocalDateTime deletedAt;
+
+    public void delete() {
+        this.deletedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/example/shimpyo/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/shimpyo/domain/user/controller/UserController.java
@@ -15,14 +15,14 @@ import java.util.Map;
 
 @Slf4j
 @RequiredArgsConstructor
-@RequestMapping("/api/user/")
+@RequestMapping("/api/user/mypage")
 @RestController
 @Tag(name = "User", description = "유저 관련 API")
 public class UserController {
 
     private final UserService userService;
 
-    @PatchMapping("/mypage")
+    @PatchMapping("/nickname")
     public ResponseEntity<Void> changeNickname(@AuthenticationPrincipal UserDetails user,
                                                @RequestBody Map<String, String> requestDto) {
         String newNickname = requestDto.get("nickname");

--- a/src/main/java/com/example/shimpyo/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/shimpyo/domain/user/controller/UserController.java
@@ -34,10 +34,11 @@ public class UserController {
     }
 
     @GetMapping("/nickname")
-    public ResponseEntity<Boolean> checkNickname(@RequestParam("nickname") String nickname) {
+    public ResponseEntity<Void> checkNickname(@RequestParam("nickname") String nickname) {
         if (!nickname.matches("^[a-zA-Z0-9가-힣_]{2,20}$")) {
             throw new BaseException(MemberExceptionType.NICKNAME_NOT_VALID);
         }
-        return ResponseEntity.ok(userService.checkNickname(nickname));
+        userService.checkNickname(nickname);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/example/shimpyo/domain/user/service/UserService.java
+++ b/src/main/java/com/example/shimpyo/domain/user/service/UserService.java
@@ -21,7 +21,8 @@ public class UserService {
                 .changeNickname(nickname);
     }
 
-    public boolean checkNickname(String nickname) {
-        return userRepository.existsByNickname(nickname);
+    public void checkNickname(String nickname) {
+        if (userRepository.existsByNickname(nickname))
+            throw new BaseException(MemberExceptionType.NICKNAME_DUPLICATED);
     }
 }

--- a/src/main/java/com/example/shimpyo/global/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/shimpyo/global/GlobalExceptionHandler.java
@@ -2,10 +2,15 @@ package com.example.shimpyo.global;
 
 import com.example.shimpyo.global.exceptionType.ExceptionType;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
 
 @Slf4j
 @RestControllerAdvice
@@ -15,6 +20,19 @@ public class GlobalExceptionHandler {
         ExceptionType exceptionType = e.getExceptionType();
         return ResponseEntity.status(exceptionType.httpStatus())
                 .body(ErrorResponse.of(exceptionType));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Object> handleMethodArgumentNotValid (MethodArgumentNotValidException e) {
+
+        log.warn("handleMethodArgumentNotValidException : {}", "Invalid Arguments");
+        String errMsg = e.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .findFirst()
+                .map(FieldError::getDefaultMessage)
+                .orElse("Validation failed");
+        return ResponseEntity.badRequest().body(errMsg);
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/example/shimpyo/global/exceptionType/AuthException.java
+++ b/src/main/java/com/example/shimpyo/global/exceptionType/AuthException.java
@@ -11,7 +11,9 @@ public enum AuthException implements ExceptionType{
     PASSWORD_NOT_MATCHED(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
     LOGIN_ID_DUPLICATION(HttpStatus.BAD_REQUEST, "중복된 아이디가 존재합니다."),
     USERNAME_NOT_VALIDATE(HttpStatus.BAD_REQUEST, "아이디가 유효하지 않습니다.[영 소문자 + 숫자 (6~12자)]"),
-    INVALID_EMAIL_REQUEST(HttpStatus.BAD_REQUEST, "이메일이 존재하지 않습니다.");
+    INVALID_EMAIL_REQUEST(HttpStatus.BAD_REQUEST, "이메일이 존재하지 않습니다."),
+    TWO_PASSWORD_NOT_MATCHED(HttpStatus.BAD_REQUEST, "새로 입력한 비밀번호가 일치하지 않습니다."),
+    PASSWORD_DUPLICATED(HttpStatus.BAD_REQUEST, "기존 비밀번호와 동일한 비밀번호입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/example/shimpyo/global/exceptionType/MemberExceptionType.java
+++ b/src/main/java/com/example/shimpyo/global/exceptionType/MemberExceptionType.java
@@ -14,7 +14,8 @@ public enum MemberExceptionType implements ExceptionType{
     INVALID_PROFILE_IMAGE(BAD_REQUEST, "잘못된 형식의 프로필 사진입니다."),
     EMAIL_DUPLICATION(BAD_REQUEST, "이미 가입된 이메일 입니다."),
     EMAIL_NOT_FOUNDED(BAD_REQUEST, "해당 이메일이 존재하지 않습니다."),
-    NICKNAME_NOT_VALID(BAD_REQUEST, "닉네임 형식이 올바르지 않습니다.");
+    NICKNAME_NOT_VALID(BAD_REQUEST, "닉네임 형식이 올바르지 않습니다."),
+    NICKNAME_DUPLICATED(BAD_REQUEST, "중복된 닉네임입니다.");
 
     private final HttpStatus status;
     private final String message;


### PR DESCRIPTION
### ⚡이슈 번호
resolve #32
resolve #34
---
### ✅ PR 종류
- [x] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
- 회원가입 시 비밀번호 형식 검증 추가
- 회원가입 시 아이디, 비밀번호 형식 검증 controller 단에서 하도록 수정 -> AuthService의 validateUsername 메서드 삭제
- 닉네임 중복 검사 시 true / false로 반환되던 값 void로 변경 후 성공이면 200 OK, 실패면 NICKNAME_DUPLICATED exception 반환하도록 수정 (현지님 요청)
- 비밀번호 찾기 시 이메일로 임시 비밀번호 전송
- 비밀번호 재설정 구현
- 회원탈퇴 구현중 -> 로컬 회원은 검증 후 soft delete, 소셜 회원은 kakao 서버로 unlink 요청 후 soft delete 예정
---
### 📖 참고 사항
