### PR TITLE
swagger에 error response 추가

### DIFF
--- a/src/main/java/com/example/shimpyo/config/SecurityConfig.java
+++ b/src/main/java/com/example/shimpyo/config/SecurityConfig.java
@@ -38,7 +38,8 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.PUT, "/api/user/auth/password").authenticated()
                         .requestMatchers(HttpMethod.POST, "/api/tourlist/reviews").authenticated()
                         .requestMatchers(HttpMethod.PATCH, "/api/user/auth/password").permitAll()
-                        .requestMatchers("/api/user/auth/**", "/api/main/recommends", "/api/tourlist/reviews").permitAll()
+                        .requestMatchers("/api/user/auth/**", "/api/main/recommends", "/api/tourlist/reviews",
+                                "/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtTokenFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/example/shimpyo/config/SwaggerConfig.java
+++ b/src/main/java/com/example/shimpyo/config/SwaggerConfig.java
@@ -1,7 +1,11 @@
 package com.example.shimpyo.config;
 
+import com.example.shimpyo.global.ExampleHolder;
+import com.example.shimpyo.global.SwaggerErrorApi;
+import com.example.shimpyo.global.exceptionType.ExceptionType;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.examples.Example;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
@@ -13,8 +17,12 @@ import io.swagger.v3.oas.models.media.MediaType;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.responses.ApiResponses;
+import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.HandlerMethod;
+
+import java.util.*;
 
 @Configuration
 public class SwaggerConfig {
@@ -69,5 +77,93 @@ public class SwaggerConfig {
                 .type("object")
                 .addProperty("accessToken", new Schema<>().type("string"))
                 .addProperty("refreshToken", new Schema<>().type("string"));
+    }
+
+    @Bean
+    public OperationCustomizer customize() {
+        return (Operation operation, HandlerMethod handlermethod) -> {
+            SwaggerErrorApi swaggerErrorApi = handlermethod.getMethodAnnotation(SwaggerErrorApi.class);
+
+            if (swaggerErrorApi != null) {
+                generateMultiErrorCodeResponse(operation, swaggerErrorApi);
+
+            }
+            return operation;
+        };
+    }
+
+    private void generateMultiErrorCodeResponse(Operation operation, SwaggerErrorApi annotation) {
+
+        ApiResponses responses = operation.getResponses();
+
+        Class<? extends ExceptionType>[] types = annotation.type();
+        Set<String> allowedCodes = new HashSet<>(Arrays.asList(annotation.codes()));
+
+        for (Class<? extends ExceptionType> type : types) {
+            ExceptionType[] errorCodes = type.getEnumConstants();
+            if (errorCodes == null) continue; // 혹시 enum이 아닌 클래스가 들어온 경우 방지
+
+            for (ExceptionType errorCode : errorCodes) {
+                if (!allowedCodes.contains(errorCode.name())) continue;
+
+                ExampleHolder exampleHolder = ExampleHolder.builder()
+                        .holder(getSwaggerExample(errorCode))
+                        .name(errorCode.name())
+                        .code(errorCode.httpStatus().value())
+                        .build();
+
+                addExamplesToResponses(responses, exampleHolder);
+            }
+        }
+    }
+
+    private Map<String, Example> getSwaggerExample(ExceptionType errorCode) {
+        Example example = new Example();
+        example.setSummary(errorCode.name());
+        example.setDescription(errorCode.message());
+        example.setValue(Map.of(
+                "status", errorCode.httpStatus().value(),
+                "code", errorCode.name(),
+                "message", errorCode.message()
+        ));
+
+        return Map.of(errorCode.name(), example);
+    }
+
+    private void addExamplesToResponses(ApiResponses responses, ExampleHolder exampleHolder) {
+        String statusCode = String.valueOf(exampleHolder.getCode());
+
+        ApiResponse existingResponse = responses.get(statusCode);
+
+        if (existingResponse == null) {
+            // 응답이 없으면 새로 생성
+            existingResponse = new ApiResponse()
+                    .description("Error Response")
+                    .content(new Content().addMediaType(
+                            org.springframework.http.MediaType.APPLICATION_JSON_VALUE,
+                            new MediaType().examples(exampleHolder.getHolder())
+                    ));
+            responses.addApiResponse(statusCode, existingResponse);
+        } else {
+            // 기존 응답이 있으면 examples만 추가
+            Content content = existingResponse.getContent();
+            if (content != null) {
+                MediaType mediaType = content.get(org.springframework.http.MediaType.APPLICATION_JSON_VALUE);
+                if (mediaType != null) {
+                    Map<String, Example> newExamples;
+                    if (mediaType.getExamples() != null) {
+                        // ✅ 기존 예제를 복사해서 수정 가능하게 만듦
+                        newExamples = new HashMap<>(mediaType.getExamples());
+                        newExamples.putAll(exampleHolder.getHolder());
+                    } else {
+                        newExamples = exampleHolder.getHolder();
+                    }
+                    mediaType.setExamples(newExamples);
+                } else {
+                    mediaType = new MediaType().examples(exampleHolder.getHolder());
+                    content.addMediaType(org.springframework.http.MediaType.APPLICATION_JSON_VALUE, mediaType);
+                }
+            }
+        }
     }
 }

--- a/src/main/java/com/example/shimpyo/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/shimpyo/domain/auth/controller/AuthController.java
@@ -123,7 +123,8 @@ public class AuthController {
 
     @Operation(summary = "비밀번호 변경")
     @SwaggerErrorApi(type = {AuthException.class, MemberExceptionType.class},
-            codes = {"PASSWORD_NOT_MATCHED", "TWO_PASSWORD_NOT_MATCHED", "PASSWORD_DUPLICATED", "MEMBER_NOT_FOUND"})
+            codes = {"PASSWORD_NOT_MATCHED", "TWO_PASSWORD_NOT_MATCHED", "PASSWORD_DUPLICATED", "MEMBER_NOT_FOUND",
+            "SOCIAL_USER_CANT_CHANGE_PASSWORD"})
     @PutMapping("/password")
     public ResponseEntity<Void> resetPassword(@Valid @RequestBody ResetPasswordRequestDto requestDto) {
         authService.resetPassword(requestDto);

--- a/src/main/java/com/example/shimpyo/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/shimpyo/domain/auth/controller/AuthController.java
@@ -39,6 +39,7 @@ public class AuthController {
     }
 
     // [#MOO3] 유저 로그인 시작
+    //TODO 미사용
     @SwaggerErrorApi(type = AuthException.class, codes = {"MEMBER_NOT_FOUND", "MEMBER_INFO_NOT_MATCHED"})
     @PostMapping("/login")
     public ResponseEntity<?> login(@RequestBody UserLoginDto dto, HttpServletResponse response) {

--- a/src/main/java/com/example/shimpyo/domain/auth/service/OAuth2Service.java
+++ b/src/main/java/com/example/shimpyo/domain/auth/service/OAuth2Service.java
@@ -129,6 +129,5 @@ public class OAuth2Service {
                 entity,
                 String.class                     // 응답 타입
         );
-        System.out.println("success : " + exchange.getBody());
     }
 }

--- a/src/main/java/com/example/shimpyo/domain/course/controller/CourseController.java
+++ b/src/main/java/com/example/shimpyo/domain/course/controller/CourseController.java
@@ -17,13 +17,13 @@ import java.util.Map;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/course")
-public class LikesController {
+public class CourseController {
     private final LikesService likesService;
 
     @Operation(summary = "관광지 찜 추가/삭제")
     @SwaggerErrorApi(type = {TouristException.class, MemberExceptionType.class},
             codes = {"TOURIST_NOT_FOUND", "MEMBER_NOT_FOUND"})
-    @PatchMapping
+    @PatchMapping("/tourist")
     public ResponseEntity<Void> toggleLikeTourist(@RequestBody Map<String, Long> requestDto) {
         likesService.toggleLikeTourist(requestDto.get("id"));
         return ResponseEntity.ok().build();

--- a/src/main/java/com/example/shimpyo/domain/course/controller/LikesController.java
+++ b/src/main/java/com/example/shimpyo/domain/course/controller/LikesController.java
@@ -1,6 +1,9 @@
-package com.example.shimpyo.domain.likes.controller;
+package com.example.shimpyo.domain.course.controller;
 
-import com.example.shimpyo.domain.likes.service.LikesService;
+import com.example.shimpyo.domain.course.service.LikesService;
+import com.example.shimpyo.global.SwaggerErrorApi;
+import com.example.shimpyo.global.exceptionType.MemberExceptionType;
+import com.example.shimpyo.global.exceptionType.TouristException;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -13,12 +16,14 @@ import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/likes")
+@RequestMapping("/api/course")
 public class LikesController {
     private final LikesService likesService;
 
-    @PatchMapping
     @Operation(summary = "관광지 찜 추가/삭제")
+    @SwaggerErrorApi(type = {TouristException.class, MemberExceptionType.class},
+            codes = {"TOURIST_NOT_FOUND", "MEMBER_NOT_FOUND"})
+    @PatchMapping
     public ResponseEntity<Void> toggleLikeTourist(@RequestBody Map<String, Long> requestDto) {
         likesService.toggleLikeTourist(requestDto.get("id"));
         return ResponseEntity.ok().build();

--- a/src/main/java/com/example/shimpyo/domain/course/repository/LikesRepository.java
+++ b/src/main/java/com/example/shimpyo/domain/course/repository/LikesRepository.java
@@ -1,4 +1,4 @@
-package com.example.shimpyo.domain.likes.controller.repository;
+package com.example.shimpyo.domain.course.repository;
 
 import com.example.shimpyo.domain.tourist.entity.Category;
 import com.example.shimpyo.domain.tourist.entity.Tourist;

--- a/src/main/java/com/example/shimpyo/domain/course/service/LikesService.java
+++ b/src/main/java/com/example/shimpyo/domain/course/service/LikesService.java
@@ -1,7 +1,7 @@
-package com.example.shimpyo.domain.likes.service;
+package com.example.shimpyo.domain.course.service;
 
 import com.example.shimpyo.domain.auth.service.AuthService;
-import com.example.shimpyo.domain.likes.controller.repository.LikesRepository;
+import com.example.shimpyo.domain.course.repository.LikesRepository;
 import com.example.shimpyo.domain.tourist.entity.Category;
 import com.example.shimpyo.domain.tourist.entity.Tourist;
 import com.example.shimpyo.domain.tourist.service.TouristService;
@@ -16,7 +16,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Service
 @Transactional

--- a/src/main/java/com/example/shimpyo/domain/tourist/controller/MainController.java
+++ b/src/main/java/com/example/shimpyo/domain/tourist/controller/MainController.java
@@ -5,9 +5,9 @@ import com.example.shimpyo.domain.tourist.dto.LikesResponseDto;
 import com.example.shimpyo.domain.tourist.dto.RecommendsResponseDto;
 import com.example.shimpyo.domain.tourist.service.TouristService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,6 +17,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/main")
 @RequiredArgsConstructor
+@Tag(name = "Main", description = "메인 화면 API 목록")
 public class MainController {
 
     private final TouristService touristService;

--- a/src/main/java/com/example/shimpyo/domain/tourist/controller/TouristController.java
+++ b/src/main/java/com/example/shimpyo/domain/tourist/controller/TouristController.java
@@ -3,6 +3,10 @@ package com.example.shimpyo.domain.tourist.controller;
 import com.example.shimpyo.domain.tourist.dto.ReviewResponseDto;
 import com.example.shimpyo.domain.tourist.dto.ReviewRequestDto;
 import com.example.shimpyo.domain.tourist.service.TouristService;
+import com.example.shimpyo.global.SwaggerErrorApi;
+import com.example.shimpyo.global.exceptionType.TouristException;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -13,10 +17,13 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/tourlist")
+@Tag(name = "Tourlist", description = "관광지 관련 API 목록" )
 public class TouristController {
 
     private final TouristService touristService;
 
+    @Operation(summary = "관광지 후기 조회")
+    @SwaggerErrorApi(type = {TouristException.class}, codes = {"TOURIST_NOT_FOUND"})
     @GetMapping("/reviews")
     public ResponseEntity<List<ReviewResponseDto>> getTouristReview(@RequestParam("touristId") Long touristId,
                                                                     @RequestParam("limit") int limit,
@@ -24,7 +31,9 @@ public class TouristController {
         return ResponseEntity.ok(touristService.getTouristReview(touristId, limit, reviewId));
     }
 
+    @Operation(summary = "후기 작성")
     @PostMapping("/reviews")
+    @SwaggerErrorApi(type = {TouristException.class}, codes = {"TOURIST_NOT_FOUND"})
     public ResponseEntity<Void> createReview(@Valid @RequestBody ReviewRequestDto requestDto) {
         touristService.createReview(requestDto);
         return ResponseEntity.ok().build();

--- a/src/main/java/com/example/shimpyo/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/shimpyo/domain/user/controller/UserController.java
@@ -1,6 +1,6 @@
 package com.example.shimpyo.domain.user.controller;
 
-import com.example.shimpyo.domain.likes.service.LikesService;
+import com.example.shimpyo.domain.course.service.LikesService;
 import com.example.shimpyo.domain.user.dto.TouristLikesResponseDto;
 import com.example.shimpyo.domain.user.service.UserService;
 import com.example.shimpyo.global.BaseException;
@@ -50,6 +50,7 @@ public class UserController {
     }
 
     @Operation(summary = "찜한 관광지 목록")
+    @SwaggerErrorApi(type = {MemberExceptionType.class}, codes = {"MEMBER_NOT_FOUND"})
     @GetMapping("/likes")
     public ResponseEntity<List<TouristLikesResponseDto>> getTouristLikes(@RequestParam("category") String category,
                                                                          @RequestParam("likesId") Long id) {

--- a/src/main/java/com/example/shimpyo/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/shimpyo/domain/user/controller/UserController.java
@@ -2,7 +2,9 @@ package com.example.shimpyo.domain.user.controller;
 
 import com.example.shimpyo.domain.user.service.UserService;
 import com.example.shimpyo.global.BaseException;
+import com.example.shimpyo.global.SwaggerErrorApi;
 import com.example.shimpyo.global.exceptionType.MemberExceptionType;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,6 +22,8 @@ public class UserController {
 
     private final UserService userService;
 
+    @Operation(summary = "닉네임 변경")
+    @SwaggerErrorApi(type = {MemberExceptionType.class}, codes = {"NICKNAME_NOT_VALID", "MEMBER_NOT_FOUND"})
     @PatchMapping("/nickname")
     public ResponseEntity<Void> changeNickname(@RequestBody Map<String, String> requestDto) {
         String newNickname = requestDto.get("nickname");
@@ -30,7 +34,9 @@ public class UserController {
         return ResponseEntity.ok().build();
     }
 
+    @Operation(summary = "닉네임 중복 검사")
     @GetMapping("/nickname")
+    @SwaggerErrorApi(type = {MemberExceptionType.class}, codes = {"NICKNAME_NOT_VALID", "NICKNAME_DUPLICATED"})
     public ResponseEntity<Void> checkNickname(@RequestParam("nickname") String nickname) {
         if (!nickname.matches("^[a-zA-Z0-9가-힣_]{2,20}$")) {
             throw new BaseException(MemberExceptionType.NICKNAME_NOT_VALID);

--- a/src/main/java/com/example/shimpyo/global/ExampleHolder.java
+++ b/src/main/java/com/example/shimpyo/global/ExampleHolder.java
@@ -1,0 +1,15 @@
+package com.example.shimpyo.global;
+
+import io.swagger.v3.oas.models.examples.Example;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+@Builder
+public class ExampleHolder {
+    private Map<String, Example> holder;    // Swagger Example 객체
+    private int code;          // HTTP 상태 코드
+    private String name;       // 에러 코드 이름 (ex: “USER_404”)
+}

--- a/src/main/java/com/example/shimpyo/global/SwaggerErrorApi.java
+++ b/src/main/java/com/example/shimpyo/global/SwaggerErrorApi.java
@@ -1,0 +1,17 @@
+package com.example.shimpyo.global;
+
+import com.example.shimpyo.global.exceptionType.ExceptionType;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SwaggerErrorApi {
+
+    Class<? extends ExceptionType>[] type(); // enum 타입
+
+    String[] codes();                      // 보여줄 상수 이름만 선택
+}


### PR DESCRIPTION
### ⚡이슈 번호
resolve #61 

---
### ✅ PR 종류
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
<img width="1483" height="916" alt="image" src="https://github.com/user-attachments/assets/41249412-8d64-4a63-8e69-27b927f02798" />
- api 명세서에 일일히 추가하기 시러서. swagger에서 custom한 error response 띄울 수 있도록 했습니다.
    번거로우시겠지만, 앞으로 기능 개발할 때 Controller 단에서 Operation -> SwaggerErrorApi -> RequestMapping 순으로 작성해주시면 감사하겠습니다.
- 토큰 관련 예외는 토큰이 필요한 api에서 공통으로 발생하기 때문에 따로 빼두었습니다. 토큰 관련 예외는 추가하지 않으셔도 됩니다.
<img width="1161" height="343" alt="image" src="https://github.com/user-attachments/assets/3d79f9b0-6513-4a45-840f-d8498e1e6156" />
- @SwaggerErrorApi 어노테이션을 달고, type에는 배열로 발생하는 Exception의 class들을, codes에는 해당 exception의 enum name을 넣어주시면 됩니다.


<img width="1044" height="939" alt="image" src="https://github.com/user-attachments/assets/9e07f54d-fc50-4889-9b5f-d7c903bdadae" />
- 명세서 상에 /likes 도메인이 사라지고 찜 목록 관련한 api들은 /mypage로 이동하였고, 관광지 찜하기 기능만 /course 에 남아있습니다. 따라서 관련 controller와 repository, service 클래스를 course 하위로 옮겼습니다.

---
### 📖 참고 사항
