### PR TITLE
수정된 API 추가

### DIFF
--- a/src/main/java/com/example/shimpyo/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/shimpyo/domain/auth/controller/AuthController.java
@@ -162,6 +162,14 @@ public class AuthController {
         return ResponseEntity.ok(dto);
     }
 
+    @Operation(summary = "추가 정보 입력")
+    @SwaggerErrorApi(type = {MemberExceptionType.class}, codes = {"MEMBER_NOT_FOUND"})
+    @PostMapping("/info")
+    public ResponseEntity<Void> getMoreInfo(@Valid @RequestBody InfoRequestDto requestDto) {
+        authService.setMoreInfo(requestDto);
+        return ResponseEntity.ok().build();
+    }
+
     @Tag(name = "ZToken", description = "토큰 관련 예외 목록")
     @Operation(summary = "토큰 관련 예외 목록")
     @SwaggerErrorApi(type = {TokenException.class},

--- a/src/main/java/com/example/shimpyo/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/shimpyo/domain/auth/controller/AuthController.java
@@ -39,7 +39,6 @@ public class AuthController {
     }
 
     // [#MOO3] 유저 로그인 시작
-    //TODO 미사용
     @SwaggerErrorApi(type = AuthException.class, codes = {"MEMBER_NOT_FOUND", "MEMBER_INFO_NOT_MATCHED"})
     @PostMapping("/login")
     public ResponseEntity<?> login(@RequestBody UserLoginDto dto, HttpServletResponse response) {
@@ -53,8 +52,9 @@ public class AuthController {
     @Operation(summary = "회원가입")
     @SwaggerErrorApi(type = AuthException.class, codes = {"EMAIL_DUPLICATION"})
     @PostMapping("/signup")
-    public ResponseEntity<?> registerUser(@Valid @RequestBody RegisterUserRequest dto){
-        authService.registerUser(dto);
+    public ResponseEntity<?> registerUser(@Valid @RequestBody RegisterUserRequest dto,
+                                          HttpServletResponse response){
+        authService.registerUser(dto, response);
         return ResponseEntity.ok("회원가입 완료");
     }
     // [#MOO1] 사용자 회원가입 끝N

--- a/src/main/java/com/example/shimpyo/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/shimpyo/domain/auth/controller/AuthController.java
@@ -31,9 +31,9 @@ public class AuthController {
     private final AuthService  authService;
     private final MailService mailService;
 
-    @Operation(summary = "소셜 회원가입")
+    @Operation(summary = "소셜 로그인/회원가입")
     @PostMapping("/social/login")
-    public ResponseEntity<LoginResponseDto> getKaKaoToken(@RequestBody Map<String, String> requestDto,
+    public ResponseEntity<SocialLoginResponseDto> getKaKaoToken(@RequestBody Map<String, String> requestDto,
                                                           HttpServletResponse response) throws JsonProcessingException {
         return ResponseEntity.ok(oAuth2Service.kakaoLogin(requestDto.get("accessToken"),response));
     }

--- a/src/main/java/com/example/shimpyo/domain/auth/dto/InfoRequestDto.java
+++ b/src/main/java/com/example/shimpyo/domain/auth/dto/InfoRequestDto.java
@@ -1,0 +1,20 @@
+package com.example.shimpyo.domain.auth.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class InfoRequestDto {
+    @NotNull(message = "성별은 필수입니다.")
+    @Pattern(regexp = "^(female|male)$", message = "성별은 female 또는 male이어야 합니다.")
+    private String gender;
+
+    @Min(value = 1900, message = "출생년도는 1900년 이후여야 합니다.")
+    @Max(value = 2025, message = "출생년도는 2025년 이전이어야 합니다.")
+    private Integer birthYear;
+}

--- a/src/main/java/com/example/shimpyo/domain/auth/dto/SocialLoginResponseDto.java
+++ b/src/main/java/com/example/shimpyo/domain/auth/dto/SocialLoginResponseDto.java
@@ -1,0 +1,30 @@
+package com.example.shimpyo.domain.auth.dto;
+
+import com.example.shimpyo.domain.auth.entity.UserAuth;
+import com.example.shimpyo.domain.user.entity.User;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SocialLoginResponseDto {
+
+    private Long userId;
+    private String nickname;
+    private String type;
+
+    public static SocialLoginResponseDto toDto(UserAuth user, boolean isSignUp) {
+        return SocialLoginResponseDto.builder()
+                .userId(user.getUser().getId())
+                .nickname(user.getUser().getNickname())
+                .type(isSignUp? "signup" : "login")
+                .build();
+    }
+
+    public static SocialLoginResponseDto toDto(User user) {
+        return SocialLoginResponseDto.builder()
+                .userId(user.getId())
+                .nickname(user.getNickname())
+                .build();
+    }
+}

--- a/src/main/java/com/example/shimpyo/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/shimpyo/domain/auth/service/AuthService.java
@@ -339,4 +339,10 @@ public class AuthService {
     public UserAuth findUser() {
         return userAuthRepository.findByUserLoginId(SecurityUtils.getLoginId()).orElseThrow(() -> new BaseException(MEMBER_NOT_FOUND));
     }
+
+    public void setMoreInfo(InfoRequestDto requestDto) {
+        User user = findUser().getUser();
+        user.changeGender(requestDto.getGender());
+        user.changeBirthYear(requestDto.getBirthYear());
+    }
 }

--- a/src/main/java/com/example/shimpyo/domain/tourist/dto/ReviewResponseDto.java
+++ b/src/main/java/com/example/shimpyo/domain/tourist/dto/ReviewResponseDto.java
@@ -11,6 +11,7 @@ import java.time.format.DateTimeFormatter;
 @Builder
 public class ReviewResponseDto {
     private Long reviewId;
+    private Long userId;
     private String nickname;
     private String createdAt;
     private String contents;
@@ -19,7 +20,8 @@ public class ReviewResponseDto {
     public static ReviewResponseDto toDto(Review review, User user) {
         return ReviewResponseDto.builder()
                 .reviewId(review.getId())
-                .nickname(user.getNickname())
+                .userId(user.getId())
+                .nickname(user.getDeletedAt() == null? user.getNickname() : null)
                 .createdAt(review.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy.MM.dd")))
                 .contents(review.getContent())
                 .images(review.getImage() == null? null : String.join(", ", review.getImage()))

--- a/src/main/java/com/example/shimpyo/domain/tourist/entity/Tourist.java
+++ b/src/main/java/com/example/shimpyo/domain/tourist/entity/Tourist.java
@@ -4,6 +4,7 @@ import com.example.shimpyo.domain.common.BaseEntity;
 import com.example.shimpyo.domain.course.entity.SuggestionTourist;
 import com.example.shimpyo.domain.course.entity.UserCourseList;
 import com.example.shimpyo.domain.user.entity.Likes;
+import com.example.shimpyo.domain.user.entity.Review;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -35,6 +36,9 @@ public class Tourist extends BaseEntity {
 
     @Column
     private String address;
+
+    @Column
+    private String region;
 
     @Column
     private String image;
@@ -79,6 +83,9 @@ public class Tourist extends BaseEntity {
 
     @OneToMany(mappedBy = "tourist", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Likes> likes = new ArrayList<>();
+
+    @OneToMany(mappedBy = "tourist", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Review> reviews = new ArrayList<>();
 }
 
 

--- a/src/main/java/com/example/shimpyo/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/shimpyo/domain/user/controller/UserController.java
@@ -1,7 +1,9 @@
 package com.example.shimpyo.domain.user.controller;
 
 import com.example.shimpyo.domain.course.service.LikesService;
-import com.example.shimpyo.domain.user.dto.SeenTouristRequestDto;
+import com.example.shimpyo.domain.tourist.service.TouristService;
+import com.example.shimpyo.domain.user.dto.MyReviewDetailResponseDto;
+import com.example.shimpyo.domain.user.dto.MyReviewListResponseDto;
 import com.example.shimpyo.domain.user.dto.SeenTouristResponseDto;
 import com.example.shimpyo.domain.user.dto.TouristLikesResponseDto;
 import com.example.shimpyo.domain.user.service.UserService;
@@ -28,6 +30,7 @@ public class UserController {
 
     private final UserService userService;
     private final LikesService likesService;
+    private final TouristService touristService;
 
     @Operation(summary = "닉네임 변경")
     @SwaggerErrorApi(type = {MemberExceptionType.class}, codes = {"NICKNAME_NOT_VALID", "MEMBER_NOT_FOUND"})
@@ -65,5 +68,20 @@ public class UserController {
     @GetMapping("/tourist")
     public ResponseEntity<List<SeenTouristResponseDto>> getLastSeenTourists(@RequestBody List<Long> touristIds){//SeenTouristRequestDto requestDto) {
         return ResponseEntity.ok(userService.getLastSeenTourists(touristIds));
+    }
+
+    @Operation(summary = "내가 쓴 후기 목록")
+    @SwaggerErrorApi(type = {MemberExceptionType.class}, codes = {"MEMBER_NOT_FOUND"})
+    @GetMapping("/review")
+    public ResponseEntity<List<MyReviewListResponseDto>> getMyReviewList() {
+        return ResponseEntity.ok(touristService.getMyReviewTourists());
+    }
+
+    @Operation(summary = "내가 쓴 후기 상세")
+    @SwaggerErrorApi(type = {MemberExceptionType.class, TouristException.class},
+            codes = {"MEMBER_NOT_FOUND", "TOURIST_NOT_FOUND", "REVIEW_NOT_FOUND"})
+    @GetMapping("/review-detail")
+    public ResponseEntity<MyReviewDetailResponseDto> getMyReviewDetail(@RequestParam("touristId") Long touristId) {
+        return ResponseEntity.ok(userService.getMyReviewTourists(touristId));
     }
 }

--- a/src/main/java/com/example/shimpyo/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/shimpyo/domain/user/controller/UserController.java
@@ -1,11 +1,14 @@
 package com.example.shimpyo.domain.user.controller;
 
 import com.example.shimpyo.domain.course.service.LikesService;
+import com.example.shimpyo.domain.user.dto.SeenTouristRequestDto;
+import com.example.shimpyo.domain.user.dto.SeenTouristResponseDto;
 import com.example.shimpyo.domain.user.dto.TouristLikesResponseDto;
 import com.example.shimpyo.domain.user.service.UserService;
 import com.example.shimpyo.global.BaseException;
 import com.example.shimpyo.global.SwaggerErrorApi;
 import com.example.shimpyo.global.exceptionType.MemberExceptionType;
+import com.example.shimpyo.global.exceptionType.TouristException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -55,5 +58,12 @@ public class UserController {
     public ResponseEntity<List<TouristLikesResponseDto>> getTouristLikes(@RequestParam("category") String category,
                                                                          @RequestParam("likesId") Long id) {
         return ResponseEntity.ok(likesService.getTouristLikes(category, id));
+    }
+
+    @Operation(summary = "최근 본 관광지")
+    @SwaggerErrorApi(type = {TouristException.class}, codes = {"TOURIST_NOT_FOUND"})
+    @GetMapping("/tourist")
+    public ResponseEntity<List<SeenTouristResponseDto>> getLastSeenTourists(@RequestBody List<Long> touristIds){//SeenTouristRequestDto requestDto) {
+        return ResponseEntity.ok(userService.getLastSeenTourists(touristIds));
     }
 }

--- a/src/main/java/com/example/shimpyo/domain/user/dto/MyReviewDetailResponseDto.java
+++ b/src/main/java/com/example/shimpyo/domain/user/dto/MyReviewDetailResponseDto.java
@@ -1,0 +1,28 @@
+package com.example.shimpyo.domain.user.dto;
+
+import com.example.shimpyo.domain.tourist.entity.Tourist;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class MyReviewDetailResponseDto {
+        private Long touristId;
+        private String title;
+        private String region;
+        private String address;
+        private List<ReviewDetailDto> reviews;
+
+        public static MyReviewDetailResponseDto toDto(Tourist tourist, List<ReviewDetailDto> reviews) {
+            return MyReviewDetailResponseDto.builder()
+                    .touristId(tourist.getId())
+                    .title(tourist.getName())
+                    .region(tourist.getRegion())
+                    .address(tourist.getAddress())
+                    .reviews(reviews)
+                    .build();
+        }
+
+}

--- a/src/main/java/com/example/shimpyo/domain/user/dto/ReviewDetailDto.java
+++ b/src/main/java/com/example/shimpyo/domain/user/dto/ReviewDetailDto.java
@@ -1,0 +1,26 @@
+package com.example.shimpyo.domain.user.dto;
+
+import com.example.shimpyo.domain.user.entity.Review;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.format.DateTimeFormatter;
+
+@Getter
+@Builder
+public class ReviewDetailDto {
+
+    private Long reviewId;
+    private String createdAt;
+    private String contents;
+    private String images;
+
+    public static ReviewDetailDto toDto(Review review) {
+        return ReviewDetailDto.builder()
+                .reviewId(review.getId())
+                .createdAt(review.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy.MM.dd")))
+                .contents(review.getContent())
+                .images(review.getImage() == null? null : String.join(", ", review.getImage()))
+                .build();
+    }
+}

--- a/src/main/java/com/example/shimpyo/domain/user/dto/SeenTouristRequestDto.java
+++ b/src/main/java/com/example/shimpyo/domain/user/dto/SeenTouristRequestDto.java
@@ -1,0 +1,12 @@
+package com.example.shimpyo.domain.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class SeenTouristRequestDto {
+    private List<Integer> touristIds;
+}

--- a/src/main/java/com/example/shimpyo/domain/user/dto/SeenTouristResponseDto.java
+++ b/src/main/java/com/example/shimpyo/domain/user/dto/SeenTouristResponseDto.java
@@ -1,0 +1,27 @@
+package com.example.shimpyo.domain.user.dto;
+
+import com.example.shimpyo.domain.tourist.entity.Tourist;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SeenTouristResponseDto {
+
+    private Long id;
+    private String title;
+    private String region;
+    private String address;
+    private String operationTime;
+    private String images;
+
+    public static SeenTouristResponseDto toDto(Tourist tourist) {
+        return SeenTouristResponseDto.builder()
+                .id(tourist.getId())
+                .region(tourist.getAddress())
+                .address(tourist.getAddress())
+                .operationTime(tourist.getOperationTime())
+                .images(tourist.getImage())
+                .build();
+    }
+}

--- a/src/main/java/com/example/shimpyo/domain/user/entity/User.java
+++ b/src/main/java/com/example/shimpyo/domain/user/entity/User.java
@@ -66,6 +66,9 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Likes> likes = new ArrayList<>();
 
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Review> reviews = new ArrayList<>();
+
     public void changeNickname(String nickname) {
         this.nickname = nickname;
     }

--- a/src/main/java/com/example/shimpyo/domain/user/entity/User.java
+++ b/src/main/java/com/example/shimpyo/domain/user/entity/User.java
@@ -42,6 +42,12 @@ public class User extends BaseEntity {
     @Column(unique = true, nullable = false)
     private String nickname;
 
+    @Column
+    private String gender;
+
+    @Column
+    private Integer birthYear;
+
     // 이거 왜 있을까요??
     private Long survey;
 
@@ -62,5 +68,12 @@ public class User extends BaseEntity {
 
     public void changeNickname(String nickname) {
         this.nickname = nickname;
+    }
+
+    public void changeGender(String gender) {
+        this.gender = gender;
+    }
+    public void changeBirthYear(Integer year) {
+        this.birthYear = year;
     }
 }

--- a/src/main/java/com/example/shimpyo/domain/user/entity/User.java
+++ b/src/main/java/com/example/shimpyo/domain/user/entity/User.java
@@ -28,7 +28,7 @@ import java.util.List;
     nickname = uuid -> not null 이므로
  **/
 @SQLDelete(sql = "UPDATE `user` SET deleted_at = now(), email = UUID(), nickname = UUID() WHERE id = ?")
-@SQLRestriction("deleted_at IS NULL")
+//@SQLRestriction("deleted_at IS NULL")
 @Table(name = "\"user\"")
 public class User extends BaseEntity {
 

--- a/src/main/java/com/example/shimpyo/domain/user/service/UserService.java
+++ b/src/main/java/com/example/shimpyo/domain/user/service/UserService.java
@@ -1,5 +1,8 @@
 package com.example.shimpyo.domain.user.service;
 
+import com.example.shimpyo.domain.tourist.service.TouristService;
+import com.example.shimpyo.domain.user.dto.SeenTouristResponseDto;
+import com.example.shimpyo.domain.user.dto.TouristLikesResponseDto;
 import com.example.shimpyo.domain.user.repository.UserRepository;
 import com.example.shimpyo.global.BaseException;
 import com.example.shimpyo.global.exceptionType.MemberExceptionType;
@@ -8,6 +11,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 
 @Service
 @RequiredArgsConstructor
@@ -15,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final TouristService touristService;
 
     @Transactional()
     public void changeNickname(String nickname) {
@@ -26,5 +33,11 @@ public class UserService {
     public void checkNickname(String nickname) {
         if (userRepository.existsByNickname(nickname))
             throw new BaseException(MemberExceptionType.NICKNAME_DUPLICATED);
+    }
+
+    public List<SeenTouristResponseDto> getLastSeenTourists(List<Long> touristIds) {
+
+        return touristIds.stream().map(t -> SeenTouristResponseDto.toDto(touristService.findTourist(t)))
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/example/shimpyo/domain/user/service/UserService.java
+++ b/src/main/java/com/example/shimpyo/domain/user/service/UserService.java
@@ -1,8 +1,11 @@
 package com.example.shimpyo.domain.user.service;
 
+import com.example.shimpyo.domain.auth.service.AuthService;
 import com.example.shimpyo.domain.tourist.service.TouristService;
-import com.example.shimpyo.domain.user.dto.SeenTouristResponseDto;
-import com.example.shimpyo.domain.user.dto.TouristLikesResponseDto;
+import com.example.shimpyo.domain.user.dto.*;
+import com.example.shimpyo.domain.user.entity.Review;
+import com.example.shimpyo.domain.user.entity.User;
+import com.example.shimpyo.domain.user.repository.ReviewRepository;
 import com.example.shimpyo.domain.user.repository.UserRepository;
 import com.example.shimpyo.global.BaseException;
 import com.example.shimpyo.global.exceptionType.MemberExceptionType;
@@ -11,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -22,6 +26,7 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final TouristService touristService;
+    private final AuthService authService;
 
     @Transactional()
     public void changeNickname(String nickname) {
@@ -39,5 +44,13 @@ public class UserService {
 
         return touristIds.stream().map(t -> SeenTouristResponseDto.toDto(touristService.findTourist(t)))
                 .collect(Collectors.toList());
+    }
+
+    public MyReviewDetailResponseDto getMyReviewTourists(Long touristId) {
+
+        return MyReviewDetailResponseDto.toDto(touristService.findTourist(touristId),
+                authService.findUser().getUser().getReviews()
+                        .stream().map(ReviewDetailDto::toDto).collect(Collectors.toList()));
+
     }
 }


### PR DESCRIPTION
### ⚡이슈 번호
resolve #77 

---
### ✅ PR 종류
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
---
### 📑 변경 사항
- [소셜 로그인 시 response dto에 로그인/회원가입 여부 추가](https://github.com/ShimPyoSo/ShimPyo_BE/commit/370b0440c3c5a620c04c17e5c69d4e100c67cb46)
- [회원 가입 후 로그인(쿠키에 토큰 세팅) 로직 추가](https://github.com/ShimPyoSo/ShimPyo_BE/commit/b6df788f0a638f5095e955cf280b942cc6d17354)
-  [회원 가입 후 추가 정보 입력받기 구현](https://github.com/ShimPyoSo/ShimPyo_BE/commit/2d0e230bb7ceaf5c92ca8339e645aa1eaef44e63)
- [최근 본 관광지 구현](https://github.com/ShimPyoSo/ShimPyo_BE/commit/08354d49d7457af9306f85482fa2d114d6d5df3c)
- [후기 목록 조회시 userId 추가, 탈퇴한 회원의 닉네임은 null로 반환](https://github.com/ShimPyoSo/ShimPyo_BE/commit/5f2090144d6708491b0da094a61fafd0395cb71c)
- 소셜 회원과 일반 회원의 response 값이 달라져서 기존 LoginResponseDto에서 SocialLoginResponseDto로 변경
- Cookie에 Token을 세팅하는 로직이 로그인 이후 뿐 아니라 회원가입 후에도 필요해져서 해당 로직을 setTokenCookie 메서드로 분리
- User Entity에 성별과 출생년도 값과 setting 메서드 추가, DTO에서 값 검증하고 service단에서는 그냥 setting하도록 구현
- 소셜 로그인 후 token setting 시에 secure이 false로 되어있어 토큰이 설정 안 되던 오류 수정
- 후기 목록 조회 시 @SQLRestriction 어노테이션으로 인해 deletedAt이 null이 아닌 사용자는 조회하지 못하는 에러 발생  
    -> User나 UserAuth 같은 경우는 deletedAt이 null이 아닌 경우에도 조회해야하는 경우가 있다고 생각해서 일단 User 엔티티만 SQL Restriction을 제거했습니다(주석 처리). 의견 있으시면 말씀해주세요
---
### 📖 참고 사항
